### PR TITLE
Fetch All Products, Similar Products, Product By Category  and display them in the app ✅

### DIFF
--- a/lib/common/widgets/empty_widget.dart
+++ b/lib/common/widgets/empty_widget.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../const/resource.dart';
+class EmptyWidget extends StatelessWidget {
+  const EmptyWidget({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Image.asset(
+        R.ASSETS_IMAGES_EMPTY_PNG,
+        height: ScreenUtil().screenHeight * 0.3,
+      ),
+    );
+  }
+}

--- a/lib/src/home/controllers/home_tab_notifier.dart
+++ b/lib/src/home/controllers/home_tab_notifier.dart
@@ -34,6 +34,5 @@ class HomeTabNotifier with ChangeNotifier{
 
   void setQueryType(QueryType type){
     queryType = type;
-   print('queryType: ${type.name}');
   }
 }

--- a/lib/src/products/hooks/fetch_products.dart
+++ b/lib/src/products/hooks/fetch_products.dart
@@ -1,0 +1,68 @@
+import 'package:fashion_app/common/utils/enums.dart';
+import 'package:fashion_app/common/utils/environment.dart';
+import 'package:fashion_app/src/categories/hook/results/category_products_results.dart';
+import 'package:fashion_app/src/products/models/products_model.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:http/http.dart' as http;
+
+FetchProduct fetchProducts(QueryType queryType) {
+  final products = useState<List<Products>>([]);
+  final isLoading = useState(false);
+  final error = useState<String?>(null);
+  Future<void> fetchData() async {
+    isLoading.value = true;
+    Uri url;
+    try {
+      switch (queryType) {
+        case QueryType.all:
+          url = Uri.parse('${Environment.appBaseUrl}/api/products/');
+          break;
+        case QueryType.popular:
+          url = Uri.parse('${Environment.appBaseUrl}/api/products/popular/');
+          break;
+        case QueryType.unisex:
+          url = Uri.parse(
+              '${Environment.appBaseUrl}/api/products/byType/?clothesType=${queryType.name}');
+          break;
+        case QueryType.men:
+          url = Uri.parse(
+              '${Environment.appBaseUrl}/api/products/byType/?clothesType=${queryType.name}');
+          break;
+        case QueryType.women:
+          url = Uri.parse(
+              '${Environment.appBaseUrl}/api/products/byType/?clothesType=${queryType.name}');
+          break;
+        case QueryType.kids:
+          url = Uri.parse(
+              '${Environment.appBaseUrl}/api/products/byType/?clothesType=${queryType.name}');
+          break;
+      }
+      final response = await http.get(url);
+      if (response.statusCode == 200) {
+        products.value = productsFromJson(response.body);
+      }
+    } catch (e) {
+      error.value = e.toString();
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  // this will run only once when there is a change in queryType
+  useEffect(() {
+    fetchData();
+    return;
+  }, [queryType.index]);
+
+  void refetch() {
+    isLoading.value = true;
+    fetchData();
+  }
+
+  return FetchProduct(
+    products: products.value,
+    isLoading: isLoading.value,
+    error: error.value,
+    refetch: refetch,
+  );
+}

--- a/lib/src/products/hooks/fetch_similar_product.dart
+++ b/lib/src/products/hooks/fetch_similar_product.dart
@@ -1,0 +1,45 @@
+import 'package:fashion_app/common/utils/environment.dart';
+import 'package:fashion_app/const/constants.dart';
+import 'package:fashion_app/src/categories/hook/results/categories_resutls.dart';
+import 'package:fashion_app/src/categories/hook/results/category_products_results.dart';
+import 'package:fashion_app/src/categories/model/categories_model.dart';
+import 'package:fashion_app/src/products/models/products_model.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:http/http.dart' as http;
+
+FetchProduct fetchSimilarProducts(int categoryId) {
+  final products = useState<List<Products>>([]);
+  final isLoading = useState(false);
+  final error = useState<String?>(null);
+  Future<void> fetchData() async {
+    isLoading.value = true;
+    try {
+      Uri url = Uri.parse('${Environment.appBaseUrl}/api/products/recommendations/?category=$categoryId');
+      final response = await http.get(url);
+      if (response.statusCode == 200) {
+        products.value = productsFromJson(response.body);
+      }
+    } catch (e) {
+      error.value = e.toString();
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  useEffect(() {
+    fetchData();
+    return;
+  }, const []);
+
+  void refetch() {
+    isLoading.value = true;
+    fetchData();
+  }
+
+  return FetchProduct(
+    products: products.value,
+    isLoading: isLoading.value,
+    error: error.value,
+    refetch: refetch,
+  );
+}

--- a/lib/src/products/widgets/explore_products.dart
+++ b/lib/src/products/widgets/explore_products.dart
@@ -1,48 +1,72 @@
 import 'package:fashion_app/common/widgets/login_bottom_sheet.dart';
+import 'package:fashion_app/src/home/controllers/home_tab_notifier.dart';
+import 'package:fashion_app/src/products/hooks/fetch_products.dart';
 import 'package:fashion_app/src/products/widgets/staggered_tile_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:provider/provider.dart';
 
 import '../../../common/services/storage.dart';
-import '../../../const/constants.dart';
+import '../../../common/widgets/shimmers/list_shimmer.dart';
+import '../../../const/resource.dart';
 
-class ExploreProducts extends StatelessWidget {
+class ExploreProducts extends HookWidget {
   const ExploreProducts({super.key});
 
   @override
   Widget build(BuildContext context) {
-     String? accessToken = Storage().getString('accessToken');
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 2.h),
-      child: StaggeredGrid.count(
-        crossAxisCount: 4,
-        mainAxisSpacing: 4,
-        crossAxisSpacing: 4,
-        children: List.generate(
-          products.length,
-          (index) {
-            final double mainAxisCellCount = (index % 2 == 0) ? 2.17 : 2.4;
-            final product = products[index];
-            return StaggeredGridTile.count(
-              crossAxisCellCount: 2,
-              mainAxisCellCount: mainAxisCellCount,
-              child: StaggeredTileWidget(
-                onTap: () {
-                  if(accessToken==null){
-                    loginBottomSheet(context);
-                  }
-                  else{
-                    // todo handle wishlist functionality
-                  }
+    String? accessToken = Storage().getString('accessToken');
+    final results = fetchProducts(context.watch<HomeTabNotifier>().queryType);
+    final products = results.products;
+    final isLoading = results.isLoading;
+    final error = results.error;
+
+    if (isLoading) {
+      return Padding(
+        padding: EdgeInsets.symmetric(horizontal: 12.w),
+        child: const ListShimmer(),
+      );
+    }
+    return products.isEmpty
+        ? Padding(
+            padding: const EdgeInsets.all(25),
+            child: Image.asset(
+              R.ASSETS_IMAGES_EMPTY_PNG,
+              height: ScreenUtil().screenHeight * 0.3,
+            ),
+          )
+        : Padding(
+            padding: EdgeInsets.symmetric(horizontal: 2.h),
+            child: StaggeredGrid.count(
+              crossAxisCount: 4,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+              children: List.generate(
+                products.length,
+                (index) {
+                  final double mainAxisCellCount =
+                      (index % 2 == 0) ? 2.17 : 2.4;
+                  final product = products[index];
+                  return StaggeredGridTile.count(
+                    crossAxisCellCount: 2,
+                    mainAxisCellCount: mainAxisCellCount,
+                    child: StaggeredTileWidget(
+                      onTap: () {
+                        if (accessToken == null) {
+                          loginBottomSheet(context);
+                        } else {
+                          // todo handle wishlist functionality
+                        }
+                      },
+                      index: index,
+                      product: product,
+                    ),
+                  );
                 },
-                index: index,
-                product: product,
               ),
-            );
-          },
-        ),
-      ),
-    );
+            ),
+          );
   }
 }

--- a/lib/src/products/widgets/product_by_category.dart
+++ b/lib/src/products/widgets/product_by_category.dart
@@ -7,6 +7,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:provider/provider.dart';
 import '../../../common/services/storage.dart';
+import '../../../common/widgets/empty_widget.dart';
 import '../../../common/widgets/login_bottom_sheet.dart';
 import '../../categories/hook/fetch_product_by_category.dart';
 
@@ -18,7 +19,8 @@ class ProductByCategory extends HookWidget {
   @override
   Widget build(BuildContext context) {
     String? accessToken = Storage().getString('accessToken');
-    final results = fetchProductsByCategories(context.read<CategoryNotifier>().id);
+    final results =
+        fetchProductsByCategories(context.read<CategoryNotifier>().id);
     final products = results.products;
     final isLoading = results.isLoading;
     final error = results.error;
@@ -27,35 +29,40 @@ class ProductByCategory extends HookWidget {
         body: ListShimmer(),
       );
     }
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 12.h),
-      child: StaggeredGrid.count(
-        crossAxisCount: 4,
-        mainAxisSpacing: 4,
-        crossAxisSpacing: 4,
-        children: List.generate(
-          products.length,
-          (index) {
-            final double mainAxisCellCount = (index % 2 == 0) ? 2.17 : 2.4;
-            final product = products[index];
-            return StaggeredGridTile.count(
-              crossAxisCellCount: 2,
-              mainAxisCellCount: mainAxisCellCount,
-              child: StaggeredTileWidget(
-                onTap: () {
-                  if (accessToken == null) {
-                    loginBottomSheet(context);
-                  } else {
-                    // todo handle wishlist functionality
-                  }
+    return products.isEmpty
+        ? const EmptyWidget()
+        : Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12.h),
+            child: StaggeredGrid.count(
+              crossAxisCount: 4,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+              children: List.generate(
+                products.length,
+                (index) {
+                  final double mainAxisCellCount =
+                      (index % 2 == 0) ? 2.17 : 2.4;
+                  final product = products[index];
+                  return StaggeredGridTile.count(
+                    crossAxisCellCount: 2,
+                    mainAxisCellCount: mainAxisCellCount,
+                    child: StaggeredTileWidget(
+                      onTap: () {
+                        if (accessToken == null) {
+                          loginBottomSheet(context);
+                        } else {
+                          // todo handle wishlist functionality
+                        }
+                      },
+                      index: index,
+                      product: product,
+                    ),
+                  );
                 },
-                index: index,
-                product: product,
               ),
-            );
-          },
-        ),
-      ),
-    );
+            ),
+          );
   }
 }
+
+

--- a/lib/src/products/widgets/similar_product.dart
+++ b/lib/src/products/widgets/similar_product.dart
@@ -1,48 +1,67 @@
+import 'package:fashion_app/common/widgets/empty_widget.dart';
 import 'package:fashion_app/common/widgets/login_bottom_sheet.dart';
+import 'package:fashion_app/src/products/controllers/product_notifier.dart';
+import 'package:fashion_app/src/products/hooks/fetch_similar_product.dart';
 import 'package:fashion_app/src/products/widgets/staggered_tile_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:provider/provider.dart';
 
 import '../../../common/services/storage.dart';
 import '../../../const/constants.dart';
 
-class SimilarProduct extends StatelessWidget {
+class SimilarProduct extends HookWidget {
   const SimilarProduct({super.key});
 
   @override
   Widget build(BuildContext context) {
     String? accessToken = Storage().getString('accessToken');
-    return Padding(
-      padding: EdgeInsets.all(8.h),
-      child: StaggeredGrid.count(
-        crossAxisCount: 4,
-        mainAxisSpacing: 4,
-        crossAxisSpacing: 4,
-        children: List.generate(
-          products.length,
-              (index) {
-            final double mainAxisCellCount = (index % 2 == 0) ? 2.17 : 2.4;
-            final product = products[index];
-            return StaggeredGridTile.count(
-              crossAxisCellCount: 2,
-              mainAxisCellCount: mainAxisCellCount,
-              child: StaggeredTileWidget(
-                onTap: () {
-                  if(accessToken==null){
-                    loginBottomSheet(context);
-                  }
-                  else{
-                    // todo handle wishlist functionality
-                  }
+    final results =
+        fetchSimilarProducts(context.read<ProductNotifier>().product!.category);
+
+    /// i think it should be product id
+    final products = results.products;
+    final isLoading = results.isLoading;
+    final error = results.error;
+    if(isLoading){
+      return const Center(
+        child: CircularProgressIndicator.adaptive(),
+      );
+    }
+    return products.isEmpty
+        ? const EmptyWidget()
+        : Padding(
+            padding: EdgeInsets.all(8.h),
+            child: StaggeredGrid.count(
+              crossAxisCount: 4,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+              children: List.generate(
+                products.length,
+                (index) {
+                  final double mainAxisCellCount =
+                      (index % 2 == 0) ? 2.17 : 2.4;
+                  final product = products[index];
+                  return StaggeredGridTile.count(
+                    crossAxisCellCount: 2,
+                    mainAxisCellCount: mainAxisCellCount,
+                    child: StaggeredTileWidget(
+                      onTap: () {
+                        if (accessToken == null) {
+                          loginBottomSheet(context);
+                        } else {
+                          // todo handle wishlist functionality
+                        }
+                      },
+                      index: index,
+                      product: product,
+                    ),
+                  );
                 },
-                index: index,
-                product: product,
               ),
-            );
-          },
-        ),
-      ),
-    );
+            ),
+          );
   }
 }


### PR DESCRIPTION
- Added fetchSimilarProducts hook to fetch similar products based oncategory type.
- Added fetchProduct hook to fetch all products in HomeScreen.
- Added EmptyWidget to display when there is no data on any screen.
- Integrated the created hooks into SimilarProduct, ProductByCategory, and ExploreProducts widgets.


![Screenshot_20240912_011501](https://github.com/user-attachments/assets/31416435-6444-4431-958b-f2146934e9b8)
![Screenshot_20240912_011522](https://github.com/user-attachments/assets/9d3be26f-94aa-46a5-a2db-ec6c9e0e6768)
![Screenshot_20240912_011542](https://github.com/user-attachments/assets/454c18f4-4930-4bf5-9fa3-ecbaa7fbd26f)

